### PR TITLE
Prevent messages from being lost due to multiple overlapping sync tasks

### DIFF
--- a/packages/main/src/queue/index.ts
+++ b/packages/main/src/queue/index.ts
@@ -242,7 +242,7 @@ if (process.env.NODE_ENV !== "test") {
 
 const queueOptions = {
   maxRetries: 3,
-  maxTimeout: isTest ? 150 : 10000,
+  maxTimeout: isTest ? 150 : Infinity,
   retryDelay: isTest ? 1 : 10000,
   store
 } as const


### PR DESCRIPTION
Sync tasks are run via the job queue that also handles tasks like
sending or archiving a message. The queue is only supposed to allow one
job to run at a time - if another sync task is scheduled it should not
start until the currently-running sync task has finished. But there was
a problem: the timeout for each task was set to 10 seconds, and an
initial sync takes longer than that. After adding an account multiple
sync tasks were queued up, and when the timeout expired on one a new
sync task would start resulting in multiple sync tasks running at the
same time.

Sync's job is to download new messages in each mailbox, to get updates to
messages that have already been downloaded, and to delete messages from
the cache that were removed from the mailbox server-side. To handle that
last responsibility sync marks each message record with an `updated_at`
value when it fetches the latest metadata for that message. Sync uses
the same `updated_at` value for every message in a mailbox for each
invocation. After downloading updates it deletes ane records in the
cache for the given mailbox whose `updated_at` value did not match the
value that it had just set.

Unfortunately with multiple sync tasks running in parallel task A starts
and downloads some messages, then task B starts and downloads only
messages that are newer than the ones that task A has already
downloaded. Then task B deletes the messages that task A downloaded
because those records did not have the same `updated_at` value that task
B had been assigning.

This change removes the timeout for tasks so that only one sync task
will run at a time.