### PR TITLE
Handle message headers with address groups

### DIFF
--- a/packages/main/src/models/Address.ts
+++ b/packages/main/src/models/Address.ts
@@ -59,6 +59,12 @@ export function build({
 
 const specialChar = /[()<>[]:;@\\,."]/
 
+export function flatAddresses(
+  addressesAndGroups: Array<imap.Address | imap.AddressGroup>
+): imap.Address[] {
+  return addressesAndGroups.flatMap(x => ("addresses" in x ? x.addresses : [x]))
+}
+
 // Print an address according to RFC 5322
 export function formatAddress(a: imap.Address): string {
   const rawName = a.name
@@ -71,9 +77,14 @@ export function formatAddress(a: imap.Address): string {
   return `${name} <${a.mailbox}@${a.host}>`
 }
 
-// Print list of addresses as a single string according to RFC 5322
-export function formatAddressList(as: Iterable<imap.Address>): string {
-  return Seq(as)
+/**
+ * Print list of addresses as a single string according to RFC 5322
+ */
+export function formatAddressList(
+  as: Iterable<imap.Address | imap.AddressGroup>
+): string {
+  // TODO: format groups instead of flattening
+  return Seq(flatAddresses(Array.from(as)))
     .map(formatAddress)
     .join(", ")
 }

--- a/packages/main/types/imap.d.ts
+++ b/packages/main/types/imap.d.ts
@@ -110,12 +110,12 @@ declare module "imap" {
       envelope: {
         date: Date
         subject: string | null
-        from: Address[] | null
-        sender: Address[] | null
-        replyTo: Address[] | null
-        to: Address[] | null
-        cc: Address[] | null
-        bcc: Address[] | null
+        from: (Address | AddressGroup)[] | null
+        sender: (Address | AddressGroup)[] | null
+        replyTo: (Address | AddressGroup)[] | null
+        to: (Address | AddressGroup)[] | null
+        cc: (Address | AddressGroup)[] | null
+        bcc: (Address | AddressGroup)[] | null
         inReplyTo: MessageId | null
         messageId: MessageId
       }
@@ -130,6 +130,11 @@ declare module "imap" {
       name?: string | null // e.g., person's full name
       mailbox: string // username portion of email address
       host: string // host portion of email address
+    }
+
+    export interface AddressGroup {
+      name: string
+      addresses: Address[]
     }
 
     export interface Disposition {


### PR DESCRIPTION
Each message includes headers such as `From`, `To`, `Cc`, etc. These headers contain lists of email addresses which the IMAP service parses for us. Usually addresses come back in the form, `{ name?: string, mailbox: string, host: string }`. But the email spec allows for address "groups", which IMAP sends in the form, `{ group: string, addresses: Address[] }`.

This change updates the type definitions for `imap` to communicate that data might come in the group format, and updates Poodle code so that it does not crash in these cases.